### PR TITLE
Disable building from source on failure

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -28,6 +28,7 @@ module Autoupdate
 
     script_contents = <<~EOS
       #!/bin/sh
+      export HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=1
       /bin/date && #{Autoupdate::Core.brew} #{auto_args}
     EOS
     FileUtils.mkpath(Autoupdate::Core.logs)


### PR DESCRIPTION
On default, when installation from bottle fails, homebrew would fall back to build from source.
But due to autoupdate happens at background, we cannot notice this in time and may often lead to unwanted battery drain.
I added an environment variable in the update script to prevent this, and this method is found [here](https://discourse.brew.sh/t/solved-option-to-not-build-from-source/3858)