### PR TITLE
Added keys to plist to lower os priority

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -94,8 +94,6 @@ module Autoupdate
         <true/>
         <key>LowPriorityIO</key>
         <true/>
-        <key>Nice</key>
-        <integer>20</integer>
         <key>ProcessType</key>
         <string>Background</string>
       </dict>

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -90,6 +90,14 @@ module Autoupdate
         <string>#{log_std}</string>
         <key>StartInterval</key>
         <integer>#{interval}</integer>
+        <key>LowPriorityBackgroundIO</key>
+        <true/>
+        <key>LowPriorityIO</key>
+        <true/>
+        <key>Nice</key>
+        <integer>20</integer>
+        <key>ProcessType</key>
+        <string>Background</string>
       </dict>
       </plist>
     EOS


### PR DESCRIPTION
Since auto-updating is usually not critical its daemon should play nice and try to lower its resource use when there are other higher priority task running.