### PR TITLE
Clarify language in `--status` when no plist found

### DIFF
--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -11,7 +11,7 @@ module Autoupdate
     File.exist?(Autoupdate::Core.location/"updater") && !autoupdate_running?
   end
 
-  def autoupdate_not_installed?
+  def autoupdate_not_configured?
     !File.exist?(Autoupdate::Core.plist)
   end
 
@@ -20,8 +20,8 @@ module Autoupdate
       puts "Autoupdate is installed and running."
     elsif autoupdate_installed_but_stopped?
       puts "Autoupdate is installed but stopped."
-    elsif autoupdate_not_installed?
-      puts "Autoupdate does not seem to be installed."
+    elsif autoupdate_not_configured?
+      puts "Autoupdate is not configured. Use `brew autoupdate --start` to begin."
     else
       puts <<~EOS
         Autoupdate cannot determine its status.


### PR DESCRIPTION
The "not installed" language is a bit misleading. I recently reconfigured my computer using my personal bootstrap repo which installs autoupdate, but never runs `brew autoupdate --start`. Thus, when I tried running `brew autoupdate --status`, I thought something had gone wrong with the installation (unlikely since I used a Brewfile). The previous message looks like it could be `brew` itself saying the command is not installed.

After trying `brew autoupdate --version` I realized what had happened. Since this message can only ever be displayed once the package is installed, using the term "configured" makes more sense, at least to me.