### PR TITLE
Remove RunAtLoad key

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -107,8 +107,6 @@ module Autoupdate
         <array>
             <string>#{Autoupdate::Core.location}/brew_autoupdate</string>
         </array>
-        <key>RunAtLoad</key>
-        <true/>
         <key>StandardErrorPath</key>
         <string>#{log_err}</string>
         <key>StandardOutPath</key>


### PR DESCRIPTION
RunAtLoad is not recommended in the launchd.plist manpage:

> This key should be avoided, as speculative job launches
> have an adverse effect on system-boot and user-login scenarios.

See https://github.com/DomT4/homebrew-autoupdate/issues/28#issue-671491340 for more details.