### PR TITLE
Update autoupdate.rb

### DIFF
--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -1,122 +1,123 @@
 # frozen_string_literal: true
 
 require "cli/parser"
+require "abstract_command" # Add this to require the AbstractCommand module
 
 module Homebrew
-  module_function
+  class Autoupdate < AbstractCommand # Inherit from Homebrew::AbstractCommand
+    SUBCOMMANDS = %w[start stop delete status version].freeze
 
-  SUBCOMMANDS = %w[start stop delete status version].freeze
+    def self.autoupdate_args
+      Homebrew::CLI::Parser.new do
+        usage_banner "`autoupdate` <subcommand> [<interval>] [<options>]"
+        description <<~EOS
+          An easy, convenient way to automatically update Homebrew.
 
-  def autoupdate_args
-    Homebrew::CLI::Parser.new do
-      usage_banner "`autoupdate` <subcommand> [<interval>] [<options>]"
-      description <<~EOS
-        An easy, convenient way to automatically update Homebrew.
+          This script will run `brew update` in the background once every 24 hours (by default)
+          until explicitly told to stop, utilising `launchd`.
 
-        This script will run `brew update` in the background once every 24 hours (by default)
-        until explicitly told to stop, utilising `launchd`.
+          `brew autoupdate start` [<`interval`>] [<`options`>]:
+          Start autoupdating either once every `interval` hours or once every 24 hours.
+          Please note the interval has to be passed in seconds, so 12 hours would be
+          `brew autoupdate start 43200`. If you want to start the autoupdate immediately
+          and on system boot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
+          to automatically run `brew upgrade` and/or `brew cleanup` respectively.
 
-        `brew autoupdate start` [<`interval`>] [<`options`>]:
-        Start autoupdating either once every `interval` hours or once every 24 hours.
-        Please note the interval has to be passed in seconds, so 12 hours would be
-        `brew autoupdate start 43200`. If you want to start the autoupdate immediately
-        and on system boot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
-        to automatically run `brew upgrade` and/or `brew cleanup` respectively.
+          `brew autoupdate stop`:
+          Stop autoupdating, but retain plist and logs.
 
-        `brew autoupdate stop`:
-        Stop autoupdating, but retain plist and logs.
+          `brew autoupdate delete`:
+          Cancel the autoupdate, delete the plist and logs.
 
-        `brew autoupdate delete`:
-        Cancel the autoupdate, delete the plist and logs.
+          `brew autoupdate status`:
+          Print the current status of this tool.
 
-        `brew autoupdate status`:
-        Print the current status of this tool.
+          `brew autoupdate version`:
+          Output this tool's current version, and a short changelog.
+        EOS
+        switch "--upgrade",
+               description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
+                            "then casks will be upgraded as well. Must be passed with `start`."
+        switch "--greedy",
+               description: "Upgrade casks with `--greedy` (include auto-updating casks). " \
+                            "Must be passed with `start`."
+        switch "--cleanup",
+               description: "Automatically clean Homebrew's cache and logs. Must be passed with `start`."
+        switch "--enable-notification",
+               description: "Notifications are enabled by default on macOS Catalina and newer. This flag " \
+                            "is no longer required and can be safely dropped."
+        switch "--immediate",
+               description: "Starts the autoupdate command immediately and on system boot, " \
+                            "instead of waiting for one interval (24 hours by default) to pass first. " \
+                            "Must be passed with `start`."
+        switch "--sudo",
+               description: "If a cask requires `sudo`, autoupdate will open a GUI to ask for the password. " \
+                            "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
 
-        `brew autoupdate version`:
-        Output this tool's current version, and a short changelog.
-      EOS
-      switch "--upgrade",
-             description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
-                          "then casks will be upgraded as well. Must be passed with `start`."
-      switch "--greedy",
-             description: "Upgrade casks with `--greedy` (include auto-updating casks). " \
-                          "Must be passed with `start`."
-      switch "--cleanup",
-             description: "Automatically clean Homebrew's cache and logs. Must be passed with `start`."
-      switch "--enable-notification",
-             description: "Notifications are enabled by default on macOS Catalina and newer. This flag " \
-                          "is no longer required and can be safely dropped."
-      switch "--immediate",
-             description: "Starts the autoupdate command immediately and on system boot, " \
-                          "instead of waiting for one interval (24 hours by default) to pass first. " \
-                          "Must be passed with `start`."
-      switch "--sudo",
-             description: "If a cask requires `sudo`, autoupdate will open a GUI to ask for the password. " \
-                          "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
-
-      named_args SUBCOMMANDS
-    end
-  end
-
-  def autoupdate
-    # We want to add the -- versions of subcommands as valid arguments
-    # but only when executing the command, not when displaying the help text
-    parser = autoupdate_args
-    SUBCOMMANDS.each do |subcommand|
-      parser.switch "--#{subcommand}"
-    end
-    args = parser.parse
-
-    subcommand = subcommand_from_args(args:)
-    interval = interval_from_args(args:)
-
-    raise UsageError, "This command requires a subcommand argument." if subcommand.nil?
-    if subcommand != :start && interval.present?
-      raise UsageError, "This command does not take a named argument without `start`."
-    end
-    if interval.present? && !interval.match?(/^\d+$/)
-      raise UsageError, "This subcommand only accepts integer arguments."
+        named_args SUBCOMMANDS
+      end
     end
 
-    # This entire tool is essentially a "bells and whistles" wrapper around
-    # `launchd` so Linux support is a no-go unless someone wants to put
-    # the work in to add/support it in a sustainable manner.
-    raise UsageError, "`brew autoupdate` is supported only on macOS!" unless OS.mac?
+    def self.autoupdate
+      # We want to add the -- versions of subcommands as valid arguments
+      # but only when executing the command, not when displaying the help text
+      parser = autoupdate_args
+      SUBCOMMANDS.each do |subcommand|
+        parser.switch "--#{subcommand}"
+      end
+      args = parser.parse
 
-    # Don't require anything until this point to keep help speedy.
-    require_relative "../lib/autoupdate"
+      subcommand = subcommand_from_args(args:)
+      interval = interval_from_args(args:)
 
-    case subcommand
-    when :start
-      Autoupdate.start(interval:, args:)
-    when :stop
-      Autoupdate.stop
-    when :delete
-      Autoupdate.delete
-    when :status
-      Autoupdate.status
-    when :version
-      Autoupdate.version
-    else
-      raise UsageError, "Unknown subcommand: #{args.named.first}"
+      raise UsageError, "This command requires a subcommand argument." if subcommand.nil?
+      if subcommand != :start && interval.present?
+        raise UsageError, "This command does not take a named argument without `start`."
+      end
+      if interval.present? && !interval.match?(/^\d+$/)
+        raise UsageError, "This subcommand only accepts integer arguments."
+      end
+
+      # This entire tool is essentially a "bells and whistles" wrapper around
+      # `launchd` so Linux support is a no-go unless someone wants to put
+      # the work in to add/support it in a sustainable manner.
+      raise UsageError, "`brew autoupdate` is supported only on macOS!" unless OS.mac?
+
+      # Don't require anything until this point to keep help speedy.
+      require_relative "../lib/autoupdate"
+
+      case subcommand
+      when :start
+        Autoupdate.start(interval:, args:)
+      when :stop
+        Autoupdate.stop
+      when :delete
+        Autoupdate.delete
+      when :status
+        Autoupdate.status
+      when :version
+        Autoupdate.version
+      else
+        raise UsageError, "Unknown subcommand: #{args.named.first}"
+      end
     end
-  end
 
-  def subcommand_from_args(args:)
-    choice = nil
-    SUBCOMMANDS.each do |subcommand|
-      next if args.named.first != subcommand && !args.send(:"#{subcommand}?")
-      raise UsageError, "Conflicting subcommands specified." if choice.present?
+    def self.subcommand_from_args(args:)
+      choice = nil
+      SUBCOMMANDS.each do |subcommand|
+        next if args.named.first != subcommand && !args.send(:"#{subcommand}?")
+        raise UsageError, "Conflicting subcommands specified." if choice.present?
 
-      choice = subcommand.to_sym
+        choice = subcommand.to_sym
+      end
+      choice
     end
-    choice
-  end
 
-  def interval_from_args(args:)
-    possibilities = args.named.reject { |arg| SUBCOMMANDS.include? arg }
-    raise UsageError, "This subcommand does not take more than 1 named argument." if possibilities.length > 1
+    def self.interval_from_args(args:)
+      possibilities = args.named.reject { |arg| SUBCOMMANDS.include? arg }
+      raise UsageError, "This subcommand does not take more than 1 named argument." if possibilities.length > 1
 
-    possibilities.first
+      possibilities.first
+    end
   end
 end


### PR DESCRIPTION
Update Homebrew Autoupdate external command to fix error:

Warning: Calling `brew autoupdate'. This command needs to be refactored, as it is written in a style that is deprecated! Use inherits from `Homebrew::AbstractCommand' ( see https://docs.brew.sh/External-Commands ) instead.