### PR TITLE
start: enable pinentry passphrase caching

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -78,7 +78,7 @@ module Autoupdate
       sudo_gui_script_contents = <<~EOS
         #!/bin/sh
         PATH='#{HOMEBREW_PREFIX}/bin'
-        printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
+        printf "%s\n" "OPTION allow-external-cache" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
       EOS
     elsif env_sudo
       set_env << "\nexport SUDO_ASKPASS=#{env_sudo}"


### PR DESCRIPTION
Closes https://github.com/DomT4/homebrew-autoupdate/issues/145. Ref https://github.com/GPGTools/pinentry/blob/master/doc/pinentry.texi#L483