### PR TITLE
ci: bump `actions/setup-python` to v5 and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    # You can use `directory: "/"` for workflow files stored in the default location of `.github/workflows`.
+    # (You don't need to specify `/.github/workflows` for `directory`.)
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+# <!--- NOTE: End of required stanzas. The following is all optional. -->
+      # By default, Dependabot checks for new versions on Monday at a
+      # random set time for the repository.
+    groups:
+      all-actions:
+        patterns:
+          # A wildcard that matches all dependencies in the package
+          # ecosystem. Note: using "*" may open a large pull request.
+          - "*"
+        update-types:
+          # Any packages where the highest resolvable version is minor
+          # or patch will be grouped together. Dependabot will create a
+          # separate pull request for any package that doesn't update to
+          # a minor or patch version.
+          - "minor"
+          - "patch"

--- a/.github/workflows/generate-help-output.yml
+++ b/.github/workflows/generate-help-output.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
             python-version: '3' 
 


### PR DESCRIPTION
Motivation: CI tests failure about `actions/setup-python@v4` being too old to run on GitHub Actions.
Ref https://github.com/DomT4/homebrew-autoupdate/actions/runs/12152862012/job/33889987720?pr=152