### PR TITLE
ci: sync stale issues workflow and pin actions to full commit SHA

### DIFF
--- a/.github/workflows/generate-help-output.yml
+++ b/.github/workflows/generate-help-output.yml
@@ -19,12 +19,12 @@ jobs:
           test-bot: false
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref_name }}
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
             python-version: '3' 
 

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,10 +1,10 @@
 # This file is synced from the `.github` repository, do not modify it directly.
-name: Triage issues
+name: Manage stale issues
 
 on:
   push:
     paths:
-      - .github/workflows/triage-issues.yml
+      - .github/workflows/stale-issues.yml
     branches-ignore:
       - dependabot/**
   schedule:
@@ -12,12 +12,14 @@ on:
     - cron: "0 0 * * *"
   issue_comment:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
 
 concurrency:
-  group: triage-issues
+  group: stale-issues
   cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
 
 jobs:
@@ -30,9 +32,13 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Mark/Close Stale Issues and Pull Requests
-        uses: actions/stale@v9
+        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 21
@@ -45,6 +51,7 @@ jobs:
             recent activity. It will be closed if no further activity occurs.
           exempt-issue-labels: "gsoc-outreachy,help wanted,in progress"
           exempt-pr-labels: "gsoc-outreachy,help wanted,in progress"
+          delete-branch: true
 
   bump-pr-stale:
     if: >
@@ -55,9 +62,13 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Mark/Close Stale `bump-formula-pr` and `bump-cask-pr` Pull Requests
-        uses: actions/stale@v9
+        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 2
@@ -68,17 +79,4 @@ jobs:
             pull request open, add a `help wanted` or `in progress` label.
           exempt-pr-labels: "help wanted,in progress"
           any-of-labels: "bump-formula-pr,bump-cask-pr"
-
-  lock-threads:
-    if: github.repository_owner == 'Homebrew' && github.event_name != 'issue_comment'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Lock Outdated Threads
-        uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          process-only: 'issues, prs'
-          issue-inactive-days: 30
-          add-issue-labels: outdated
-          pr-inactive-days: 30
-          add-pr-labels: outdated
+          delete-branch: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   stale:
     if: >
-      github.repository_owner == 'Homebrew' && (
+      github.repository_owner == 'DomT4' && (
         github.event_name != 'issue_comment' || (
           contains(github.event.issue.labels.*.name, 'stale') ||
           contains(github.event.pull_request.labels.*.name, 'stale')
@@ -55,7 +55,7 @@ jobs:
 
   bump-pr-stale:
     if: >
-      github.repository_owner == 'Homebrew' && (
+      github.repository_owner == 'DomT4' && (
         github.event_name != 'issue_comment' || (
           contains(github.event.issue.labels.*.name, 'stale') ||
           contains(github.event.pull_request.labels.*.name, 'stale')


### PR DESCRIPTION
- sync `triage-issues.yml` from upstream Homebrew/.github repo (renamed to `stale-issues.yml` in [Commit a85ce1d](https://github.com/Homebrew/.github/commit/a85ce1d1e59f0e1364448b76aa1c0c7e042043ed#diff-0bd376ac0f6d23a1457b2e910fd30cdd4cda10374ce15faa09c6ad26c3b82abe "https://github.com/Homebrew/.github/commit/a85ce1d1e59f0e1364448b76aa1c0c7e042043ed#diff-0bd376ac0f6d23a1457b2e910fd30cdd4cda10374ce15faa09c6ad26c3b82abe"))
- update repo owner in `stale-issues.yml`:
In `stale-issues.yml` (formerly `triage-issues.yml`), there is a condition which makes it run only when the repository owner is `Homebrew`. This means the workflow hasn't actually run for the past [11 months](https://github.com/DomT4/homebrew-autoupdate/actions/workflows/triage-issues.yml?page=16 "https://github.com/DomT4/homebrew-autoupdate/actions/workflows/triage-issues.yml?page=16"). Updated to `DomT4`.
ref https://github.com/Homebrew/brew/pull/16822
- pin GitHub Actions to a full length commit SHA (generated via [pinact run](https://formulae.brew.sh/formula/pinact#default "https://formulae.brew.sh/formula/pinact#default"))

---

Per GitHub's [security guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions):

> - Pin actions to a full length commit SHA
>   
>   Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

Dependabot helpfully [updates comments in GitHub Actions workflows referencing action versions](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/):

> GitHub Actions workflows often specify the version of an action using the commit SHA. Since commit SHAs are immutable, this ensures that Actions always picks the same version. Commit SHAs, however, are not very human friendly, so best practice is to include the semver version in a comment next to the SHA. Dependabot will now update the semver version in comments when updating Actions workflows with a commit SHA version.