### PR TITLE
version: bump to 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ brew autoupdate version:
                                    start.
       --cleanup                    Automatically clean Homebrew's cache and
                                    logs. Must be passed with start.
-      --enable-notification        Notifications are enabled by default on macOS
-                                   Catalina and newer. This flag is no longer
-                                   required and can be safely dropped.
       --immediate                  Starts the autoupdate command immediately and
                                    on system boot, instead of waiting for one
                                    interval (24 hours by default) to pass first.

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -48,10 +48,6 @@ module Homebrew
                             "Must be passed with `start`."
         switch "--cleanup",
                description: "Automatically clean Homebrew's cache and logs. Must be passed with `start`."
-
-        switch "--enable-notification",
-               description: "Notifications are enabled by default on macOS Catalina and newer. This flag " \
-                            "is no longer required and can be safely dropped."
         switch "--immediate",
                description: "Starts the autoupdate command immediately and on system boot, " \
                             "instead of waiting for one interval (24 hours by default) to pass first. " \

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -56,7 +56,9 @@ module Homebrew
                description: "If a cask requires `sudo`, autoupdate will open a GUI to ask for the password. " \
                             "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
 
-        named_args SUBCOMMANDS, max: 1
+        # Needs to be two as otherwise it breaks the passing of an interval
+        # such as: start --immediate 3600. `Error: Invalid usage:`
+        named_args SUBCOMMANDS, max: 2
       end
 
       def run

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -37,14 +37,6 @@ module Autoupdate
 
     # Enable the new AppleScript applet by default on Catalina and above.
     auto_args << " && #{Autoupdate::Notify.new_notify}" if MacOS.version >= :catalina
-    if args.enable_notification? && MacOS.version >= :catalina
-      opoo <<~EOS
-        Notifications are automatically enabled for macOS Catalina
-        and newer using a native Applet. Passing --enable-notification
-        is no longer required.
-
-      EOS
-    end
 
     # Try to respect user choice as much as possible.
     env_cache = ENV.fetch("HOMEBREW_CACHE") if ENV["HOMEBREW_CACHE"]

--- a/lib/autoupdate/version.rb
+++ b/lib/autoupdate/version.rb
@@ -33,7 +33,7 @@ module Autoupdate
 
   def version
     puts <<~EOS
-      Version 3.2.0. Last Changed: Jan 2025
+      Version 3.2.1. Last Changed: Jan 2025
 
     EOS
     generate_version_notes


### PR DESCRIPTION
9948318 version: bump to 3.2.1
a42a282 autoupdate: allow 2 args to fix regression
01613d5 start: remove deprecation warning
d839fff autoupdate: remove outdated flag