### PR TITLE
Add --leaves-only option for safer upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Just `brew tap domt4/autoupdate`.
 
 Now run `brew autoupdate start [interval] [options]` to enable autoupdate.
 
-## Examples
+## Example
 
 ```sh
 brew autoupdate start 43200 --upgrade --cleanup --immediate --sudo
@@ -27,13 +27,6 @@ brew autoupdate start 43200 --upgrade --cleanup --immediate --sudo
 This will upgrade all your casks and formulae every 12 hours and on every system boot.
 If a sudo password is required for an upgrade, a GUI to enter your password will be displayed.
 Also, it will clean up every old version and left-over files.
-
-```sh
-brew autoupdate start 43200 --upgrade --leaves-only --cleanup
-```
-
-This will only upgrade formulae that are not dependencies of another installed formula (top-level packages).
-This provides a safer upgrade strategy by reducing the risk of compatibility issues from dependency updates.
 
 Casks that have built-in auto-updates enabled by default will not be upgraded.
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,22 @@ Just `brew tap domt4/autoupdate`.
 
 Now run `brew autoupdate start [interval] [options]` to enable autoupdate.
 
-## Example
+## Examples
 
 ```sh
 brew autoupdate start 43200 --upgrade --cleanup --immediate --sudo
 ```
 
-This will upgrade all your casks and formulae every 12 hours and on every system boot.  
-If a sudo password is required for an upgrade, a GUI to enter your password will be displayed.  
+This will upgrade all your casks and formulae every 12 hours and on every system boot.
+If a sudo password is required for an upgrade, a GUI to enter your password will be displayed.
 Also, it will clean up every old version and left-over files.
+
+```sh
+brew autoupdate start 43200 --upgrade --leaves-only --cleanup
+```
+
+This will only upgrade formulae that are not dependencies of another installed formula (top-level packages).
+This provides a safer upgrade strategy by reducing the risk of compatibility issues from dependency updates.
 
 Casks that have built-in auto-updates enabled by default will not be upgraded.
 

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -55,6 +55,10 @@ module Homebrew
         switch "--sudo",
                description: "If a cask requires `sudo`, autoupdate will open a GUI to ask for the password. " \
                             "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
+        switch "--leaves-only",
+               description: "Only upgrade formulae that are not dependencies of another installed formula. " \
+                            "This provides a safer upgrade strategy by only updating top-level packages. " \
+                            "Must be passed with `--upgrade`and `start`."
 
         # Needs to be two as otherwise it breaks the passing of an interval
         # such as: start --immediate 3600. `Error: Invalid usage:`

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -58,7 +58,7 @@ module Homebrew
         switch "--leaves-only",
                description: "Only upgrade formulae that are not dependencies of another installed formula. " \
                             "This provides a safer upgrade strategy by only updating top-level packages. " \
-                            "Must be passed with `--upgrade`and `start`."
+                            "Must be passed with `--upgrade` and `start`."
 
         # Needs to be two as otherwise it breaks the passing of an interval
         # such as: start --immediate 3600. `Error: Invalid usage:`

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -13,6 +13,14 @@ module Autoupdate
       EOS
     end
 
+    # Validate that --leaves-only is only used with --upgrade
+    if args.leaves_only? && !args.upgrade?
+      odie <<~EOS
+        The `--leaves-only` option must be used with `--upgrade`.
+        Please run with both options: `brew autoupdate start --upgrade --leaves-only`
+      EOS
+    end
+
     auto_args = "update"
     # Spacing at start of lines is deliberate. Don't undo.
     if args.upgrade?

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -16,7 +16,12 @@ module Autoupdate
     auto_args = "update"
     # Spacing at start of lines is deliberate. Don't undo.
     if args.upgrade?
-      auto_args << " && #{Autoupdate::Core.brew} upgrade --formula -v"
+      if args.leaves_only?
+        # For --leaves-only, we need to get the list of leaves and upgrade only those
+        auto_args << " && #{Autoupdate::Core.brew} leaves | xargs #{Autoupdate::Core.brew} upgrade --formula -v"
+      else
+        auto_args << " && #{Autoupdate::Core.brew} upgrade --formula -v"
+      end
 
       if (HOMEBREW_PREFIX/"Caskroom").exist?
         if ENV["SUDO_ASKPASS"].nil? && !args.sudo?

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -21,9 +21,15 @@ module Autoupdate
         # We create a temporary script to handle this safely
         temp_script = <<~SCRIPT
           #!/bin/bash
+          set -e
           LEAVES=$(#{Autoupdate::Core.brew} leaves)
           if [ -n "$LEAVES" ]; then
-            #{Autoupdate::Core.brew} upgrade --formula -v $(echo "$LEAVES")
+            echo "Upgrading leaves packages only..."
+            #{Autoupdate::Core.brew} upgrade --formula -v $(echo "$LEAVES") || {
+              echo "Warning: Some leaves packages failed to upgrade."
+              # Return 0 to ensure the autoupdate process continues
+              exit 0
+            }
           else
             echo "No leaves packages to upgrade."
           fi

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -45,6 +45,8 @@ module Autoupdate
 
         # Create a temporary script file
         script_path = Autoupdate::Core.location/"brew_autoupdate_leaves"
+        # Ensure the directory exists
+        FileUtils.mkpath(Autoupdate::Core.location)
         File.open(script_path, "w") { |f| f << temp_script }
         FileUtils.chmod 0555, script_path
 

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -51,7 +51,8 @@ module Autoupdate
         FileUtils.chmod 0555, script_path
 
         # Add the script to the auto_args
-        auto_args << " && #{script_path}"
+        # Use quotes around the script path to handle spaces
+        auto_args << " && \"#{script_path}\""
       else
         auto_args << " && #{Autoupdate::Core.brew} upgrade --formula -v"
       end


### PR DESCRIPTION
This PR adds a new option `--leaves-only` that only upgrades formulae that are not dependencies of another installed formula (top-level packages). This provides a safer upgrade strategy by reducing the risk of compatibility issues from dependency updates.

The option works by using the output of `brew leaves` to determine which packages to upgrade, rather than upgrading all installed packages.