### PR TITLE
Fix help output generation github action

### DIFF
--- a/.github/generate-help-output.py
+++ b/.github/generate-help-output.py
@@ -15,8 +15,8 @@ if not os.path.exists(readme_file):
 with open(readme_file, "r") as f:
     readme_content = f.read()
 
-start_comment_tag = "[comment]: # (HELP-COMMAND-OUTPUT:START)"
-stop_comment_tag = "[comment]: # (HELP-COMMAND-OUTPUT:END)"
+start_comment_tag = "<!-- HELP-COMMAND-OUTPUT:START -->"
+stop_comment_tag = "<!-- HELP-COMMAND-OUTPUT:END -->"
 
 comment_tag_pattern = rf"{start_comment_tag}(.*?){stop_comment_tag}"
 tag_section_content = re.search(comment_tag_pattern, readme_content, re.DOTALL)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Casks that have built-in auto-updates enabled by default will not be upgraded.
 
 ## Usage
 
-[comment]: # (HELP-COMMAND-OUTPUT:START)
+<!-- HELP-COMMAND-OUTPUT:START -->
 
 ```help
 Usage: brew autoupdate subcommand [interval] [options]
@@ -85,7 +85,7 @@ brew autoupdate version:
   -h, --help                       Show this message.
 ```
 
-[comment]: # (HELP-COMMAND-OUTPUT:END)
+<!-- HELP-COMMAND-OUTPUT:END -->
 
 **Logs of the performed operations can be found at:** `~/Library/Logs/com.github.domt4.homebrew-autoupdate`
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ brew autoupdate version:
                                    open a GUI to ask for the password. Requires
                                    https://formulae.brew.sh/formula/pinentry-mac
                                    to be installed.
+      --leaves-only                Only upgrade formulae that are not
+                                   dependencies of another installed formula.
+                                   This provides a safer upgrade strategy by
+                                   only updating top-level packages. Must be
+                                   passed with --upgrade and start.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.


### PR DESCRIPTION
The generation of the help output in the README.md file stopped working after the merge of PR: https://github.com/DomT4/homebrew-autoupdate/pull/166/files. (The GitHub action fails, but does not send the correct exit code for GitHub to detect the error. This needs to be fixed in another PR.)

I now reverted the start/stop tags from this commit: https://github.com/DomT4/homebrew-autoupdate/pull/166/commits/0c4d5a4337e0ea5cc221cf8f193fce7eda24799a

```
start_comment_tag = "<!-- HELP-COMMAND-OUTPUT:START -->"
stop_comment_tag = "<!-- HELP-COMMAND-OUTPUT:END -->"
```

Action: [Generate --help output](https://github.com/DomT4/homebrew-autoupdate/actions/runs/14806202336/job/41574781398)

`Run python .github/generate-help-output.py`: 
```
Error: Unable to find [comment]: # (HELP-COMMAND-OUTPUT:START) and [comment]: # (HELP-COMMAND-OUTPUT:END) in README.md.

```