### PR TITLE
Add a new option to preserve dock layout

### DIFF
--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -59,6 +59,9 @@ module Homebrew
                description: "Only upgrade formulae that are not dependencies of another installed formula. " \
                             "This provides a safer upgrade strategy by only updating top-level packages. " \
                             "Must be passed with `--upgrade` and `start`."
+        switch "--preserve-dock",
+               description: "Restores the Dock to the state it was in before autoupdate ran. " \
+                            "Must be passed with `start`."
 
         # Needs to be two as otherwise it breaks the passing of an interval
         # such as: start --immediate 3600. `Error: Invalid usage:`

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -22,6 +22,8 @@ module Autoupdate
     end
 
     auto_args = "update"
+    pre_steps = ""
+    post_steps = ""
     # Spacing at start of lines is deliberate. Don't undo.
     if args.upgrade?
       if args.leaves_only?
@@ -115,10 +117,17 @@ module Autoupdate
       set_env << "\nexport SUDO_ASKPASS=#{env_sudo}"
     end
 
+    if args.preserve_dock?
+      pre_steps << "defaults export com.apple.dock \"/tmp/brew-autoupdate-dock-layout.plist\""
+      post_steps << "defaults import com.apple.dock \"/tmp/brew-autoupdate-dock-layout.plist\" && killall Dock"
+    end
+
     script_contents = <<~EOS
       #!/bin/sh
       #{set_env}
-      /bin/date && #{Autoupdate::Core.brew} #{auto_args}
+      #{pre_steps}
+      /bin/date && #{Autoupdate::Core.brew} #{auto_args} 
+      #{post_steps}
     EOS
     FileUtils.mkpath(Autoupdate::Core.logs)
     FileUtils.mkpath(Autoupdate::Core.location)

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -126,7 +126,7 @@ module Autoupdate
       #!/bin/sh
       #{set_env}
       #{pre_steps}
-      /bin/date && #{Autoupdate::Core.brew} #{auto_args} 
+      /bin/date && #{Autoupdate::Core.brew} #{auto_args}
       #{post_steps}
     EOS
     FileUtils.mkpath(Autoupdate::Core.logs)


### PR DESCRIPTION
I noticed that every time brew autoupdates ran, apps were being removed from my dock
This new option would allow users to run autoupdate with this new mode where the dock was preserved

I'm not super familiar with ruby, but I think this is correct?



based on: https://github.com/Homebrew/homebrew-cask/issues/102721#issuecomment-1312660333

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210356475822055