### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DomT4/homebrew-autoupdate/security/code-scanning/1](https://github.com/DomT4/homebrew-autoupdate/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow only runs Homebrew commands and does not interact with GitHub resources in a way that requires write permissions, we will set `contents: read` as the minimal required permission. This ensures the workflow has only the permissions it needs to operate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
