### PR TITLE
Use an unambiguous date format in status.rb

### DIFF
--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -20,7 +20,7 @@ module Autoupdate
   def date_of_last_modification
     if File.exist?(Autoupdate::Core.location/"brew_autoupdate")
       birth = File.birthtime(Autoupdate::Core.location/"brew_autoupdate")
-      formatted_string = birth.strftime("%v")
+      formatted_string = birth.strftime("%f")
     else
       formatted_string = "Unable to determine date of command invocation. Please report this."
     end

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -19,9 +19,8 @@ module Autoupdate
 
   def date_of_last_modification
     if File.exist?(Autoupdate::Core.location/"brew_autoupdate")
-      birth = File.birthtime(Autoupdate::Core.location/"brew_autoupdate").to_s
-      date = Date.parse(birth)
-      formatted_string = date.strftime("%D")
+      birth = File.birthtime(Autoupdate::Core.location/"brew_autoupdate")
+      formatted_string = birth.strftime("%v")
     else
       formatted_string = "Unable to determine date of command invocation. Please report this."
     end

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -20,7 +20,7 @@ module Autoupdate
   def date_of_last_modification
     if File.exist?(Autoupdate::Core.location/"brew_autoupdate")
       birth = File.birthtime(Autoupdate::Core.location/"brew_autoupdate")
-      formatted_string = birth.strftime("%f")
+      formatted_string = birth.strftime("%F")
     else
       formatted_string = "Unable to determine date of command invocation. Please report this."
     end


### PR DESCRIPTION
Setting up autoupdate this morning, I was initially confused when the status message told me the launch daemon was created two months ago! Then I realised that the date uses the US `mm/dd/yyyy` format (which [few other countries use](https://en.wikipedia.org/wiki/List_of_date_formats_by_country#Usage_map)).

I'm so used to tools using regional settings when formatting dates, that this really took me by surprise! I did some digging to work out why the date wasn't being formatted with regional settings, only to find that Ruby doesn't do this automatically (at least not without a lot of [extra work!](https://softwarepatternslexicon.com/patterns-ruby/24/15/)).

So instead, I'm proposing a simple switch of format, from `%D` to `%v` because the 'VMS' format is unambiguous: `dd-MMM-yyyy`.

I've also removed what appear to be unnecessary conversions (`time` -> `string` -> `date`), but please let me know what I'm missing if these are doing something important!