### PR TITLE
fix(autoupdate): replace deprecated opoo with warn in start.rb

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -59,7 +59,7 @@ module Autoupdate
 
       if (HOMEBREW_PREFIX/"Caskroom").exist?
         if ENV["SUDO_ASKPASS"].nil? && !args.sudo?
-          opoo <<~EOS
+          warn <<~EOS
             Please note if you use Casks that require `sudo` to upgrade,
             you need to use `--sudo` or define a custom `SUDO_ASKPASS`
             environment variable.


### PR DESCRIPTION
# fix: replace deprecated opoo with warn in autoupdate start path

## Summary
This PR fixes a crash when running:

```bash
brew autoupdate start 86400 --upgrade --cleanup --immediate --ac-only
```

On recent Homebrew versions, the command failed with:

```
Error: undefined method 'opoo' for module Autoupdate
/opt/homebrew/Library/Taps/domt4/homebrew-autoupdate/lib/autoupdate/start.rb:62:in 'Autoupdate.start'
```

## Root Cause
- The failure occurs specifically when using the `--upgrade` flag.  
- The problematic call is [`opoo`](https://github.com/DomT4/homebrew-autoupdate/blob/master/lib/autoupdate/start.rb#L62).  
- `opoo` used to be a Homebrew helper for non-fatal warnings, but it is no longer available in recent versions of Homebrew.  
- As a result, the process aborts instead of just showing a warning.

## Fix
- Replaced the call to `opoo` with Ruby’s native `warn`.  
- This preserves the original intent of displaying a **non-fatal warning** while avoiding reliance on deprecated Homebrew internals.  
- The warning message itself is unchanged.

## Testing
Steps performed to validate this fix:

1. **Without fix**  
   - `brew autoupdate start` → works.  
   - `brew autoupdate start --upgrade` → crashes with `undefined method 'opoo'`.

2. **With fix applied**  
   - `brew autoupdate start` → works.  
   - `brew autoupdate start --upgrade --cleanup --immediate --ac-only` → works, shows the warning if relevant, creates LaunchAgent successfully, and autoupdate runs as expected.  
   - Verified via `brew autoupdate status` and `brew autoupdate logs --follow`.

## Risk/Impact
- Low impact: only changes a single line of code responsible for a warning message.  
- No change in functionality: still displays the same message, still non-fatal.  
- Removes dependency on deprecated Homebrew helper.  
- Users can once again enable `--upgrade` without hitting a fatal error.

## Related Issue
Closes #185
