### PR TITLE
Fix undefined method errors for 'opoo' and 'odie'

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: false
 
+require "utils/output"
+
 module Autoupdate
+  extend Utils::Output::Mixin
   module_function
 
   def start(interval:, args:)


### PR DESCRIPTION
  ## Summary
  This PR fixes the undefined method errors that occur when running `brew autoupdate` commands by properly
  including the Homebrew output utilities in the Autoupdate module.

  ## Problem
  Users were encountering errors like:
  - `Error: undefined method 'opoo' for module Autoupdate` (when casks are installed)
  - `Error: undefined method 'odie' for module Autoupdate`

  ## Solution
  - Added `require "utils/output"` to load the output utilities
  - Added `extend Utils::Output::Mixin` to make the output methods (opoo, odie, onoe, etc.) available in the
   Autoupdate module

  This follows the same pattern used throughout the Homebrew codebase for making these output methods
  available.

  ## Testing
  Tested locally with `brew autoupdate start 604800 --upgrade --cleanup --immediate` and confirmed it works
  without errors.

  Fixes #184, #185