### PR TITLE
start.rb: add icon to pinentry

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -121,8 +121,19 @@ module Autoupdate
       set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
       sudo_gui_script_contents = <<~EOS
         #!/bin/sh
-        PATH='#{HOMEBREW_PREFIX}/bin'
-        printf "%s\n" "OPTION allow-external-cache" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
+        PATH="#{HOMEBREW_PREFIX}/bin"
+        (
+          export PINENTRY_USER_DATA="ICON=#{Autoupdate::Core.location/"notifier/applet.icns"},"
+          printf "%s\n" \
+            "OPTION allow-external-cache" \
+            "SETOK OK" \
+            "SETCANCEL Cancel" \
+            "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" \
+            "SETPROMPT Enter Password:" \
+            "SETTITLE homebrew-autoupdate Password Request" \
+            "GETPIN" \
+            | pinentry-mac --no-global-grab --timeout 60
+        ) | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
       EOS
     elsif env_sudo
       set_env << "\n#{shell_export("SUDO_ASKPASS", env_sudo)}"


### PR DESCRIPTION
For what it's worth, this change is intended to make pinentry-mac show the same icon that's in this repo's notifier bundle as a badge **together with** the GPGTools icon. It's small and in the lower right corner, so I'm not sure how much of an impact this really is.
<img width="544" height="237" alt="pinentry-icon" src="https://github.com/user-attachments/assets/4b05a17b-fa7e-4991-bba1-2cd6d9fe9306" />
