### PR TITLE
Add outdated notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ duration such as 30m, 12h, 1d, or 1w.
 
 Common start options:
   --upgrade upgrades installed formulae and casks.
+  --outdated reports available upgrades.
   --cleanup cleans Homebrew's cache and logs after a successful run.
   --immediate runs immediately and whenever the launch agent is loaded.
   --only=wget,node,firefox upgrades only the listed packages.
@@ -100,6 +101,8 @@ Common start options:
   --sudo enables a GUI password prompt for cask upgrades.
   --ac-only skips runs while the Mac is on battery power.
   --notify-on-error shows notifications only for failed runs.
+  --no-notify-on-update notifies only when upgrades are available or a run
+fails.
   --no-notify disables notifications.
 
 Examples:
@@ -143,6 +146,7 @@ accepts seconds or a suffix such as 30m, 12h, or 1d.
       --upgrade                    Automatically upgrade installed formulae and
                                    casks.
       --greedy                     Include auto-updating casks when upgrading.
+      --outdated                   Report available upgrades.
       --cleanup                    Automatically clean Homebrew's cache and
                                    logs.
       --immediate                  Run immediately and on login instead of
@@ -157,6 +161,8 @@ accepts seconds or a suffix such as 30m, 12h, or 1d.
       --ac-only                    Run only while the Mac is connected to AC
                                    power.
       --notify-on-error            Notify only when an autoupdate run fails.
+      --no-notify-on-update        Notify only when upgrades are available or a
+                                   run fails. Requires --outdated.
       --no-notify                  Disable autoupdate notifications.
 
 From tap: domt4/autoupdate

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -32,6 +32,7 @@ module Homebrew
             `--sudo` enables a GUI password prompt for cask upgrades.
             `--ac-only` skips runs while the Mac is on battery power.
             `--notify-on-error` shows notifications only for failed runs.
+            `--no-notify-on-update` notifies only when upgrades are available or a run fails.
             `--no-notify` disables notifications.
 
           Examples:
@@ -83,11 +84,14 @@ module Homebrew
                  description: "Run only while the Mac is connected to AC power."
           switch "--notify-on-error",
                  description: "Notify only when an autoupdate run fails."
+          switch "--no-notify-on-update",
+                 depends_on:  "--outdated",
+                 description: "Notify only when upgrades are available or a run fails. Requires `--outdated`."
           switch "--no-notify",
                  description: "Disable autoupdate notifications."
 
           conflicts "--only", "--leaves-only"
-          conflicts "--notify-on-error", "--no-notify"
+          conflicts "--notify-on-error", "--no-notify-on-update", "--no-notify"
           named_args max: 1
         end
 

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -23,6 +23,7 @@ module Homebrew
 
           Common start options:
             `--upgrade` upgrades installed formulae and casks.
+            `--outdated` reports available upgrades.
             `--cleanup` cleans Homebrew's cache and logs after a successful run.
             `--immediate` runs immediately and whenever the launch agent is loaded.
             `--only=wget,node,firefox` upgrades only the listed packages.
@@ -62,6 +63,8 @@ module Homebrew
           switch "--greedy",
                  depends_on:  "--upgrade",
                  description: "Include auto-updating casks when upgrading."
+          switch "--outdated",
+                 description: "Report available upgrades."
           switch "--cleanup",
                  description: "Automatically clean Homebrew's cache and logs."
           switch "--immediate",

--- a/lib/autoupdate/core.rb
+++ b/lib/autoupdate/core.rb
@@ -36,7 +36,7 @@ module Autoupdate
       end
 
       path = Pathname.new(File.join(HOMEBREW_LIBRARY, "Taps", origin, "homebrew-autoupdate"))
-      path.exist? ? path : Pathname.new(File.expand_path("../../..", __dir__))
+      path.exist? ? path : Pathname.new(File.expand_path("../../..", __FILE__))
     end
   end
 end

--- a/lib/autoupdate/core.rb
+++ b/lib/autoupdate/core.rb
@@ -35,7 +35,8 @@ module Autoupdate
         "domt4"
       end
 
-      Pathname.new(File.join(HOMEBREW_LIBRARY, "Taps", origin, "homebrew-autoupdate"))
+      path = Pathname.new(File.join(HOMEBREW_LIBRARY, "Taps", origin, "homebrew-autoupdate"))
+      path.exist? ? path : Pathname.new(File.expand_path("../../..", __dir__))
     end
   end
 end

--- a/lib/autoupdate/core.rb
+++ b/lib/autoupdate/core.rb
@@ -36,7 +36,7 @@ module Autoupdate
       end
 
       path = Pathname.new(File.join(HOMEBREW_LIBRARY, "Taps", origin, "homebrew-autoupdate"))
-      path.exist? ? path : Pathname.new(File.expand_path("../../..", __FILE__))
+      path.exist? ? path : Pathname.new(File.expand_path("../..", __dir__))
     end
   end
 end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -34,6 +34,8 @@ module Autoupdate
 
     auto_args = "update"
     # Spacing at start of lines is deliberate. Don't undo.
+    # brew outdated exits 1 when packages are outdated, so || true is required.
+    auto_args << " && { #{Autoupdate::Core.brew} outdated --quiet || true; }" if args.outdated?
     if args.upgrade?
       if args.leaves_only?
         # For --leaves-only, we need to get the list of leaves and upgrade only those

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -34,8 +34,14 @@ module Autoupdate
 
     auto_args = "update"
     # Spacing at start of lines is deliberate. Don't undo.
+    # Sentinel markers allow notify.sh to extract the outdated list unambiguously,
+    # regardless of what brew update itself prints (e.g. "==> New Formulae" sections).
     # brew outdated exits 1 when packages are outdated, so || true is required.
-    auto_args << " && { #{Autoupdate::Core.brew} outdated --quiet || true; }" if args.outdated?
+    if args.outdated?
+      auto_args << " && { echo '==> autoupdate-outdated-begin'; " \
+                   "#{Autoupdate::Core.brew} outdated --quiet || true; " \
+                   "echo '==> autoupdate-outdated-end'; }"
+    end
     if args.upgrade?
       if args.leaves_only?
         # For --leaves-only, we need to get the list of leaves and upgrade only those
@@ -147,6 +153,8 @@ module Autoupdate
       "never"
     elsif args.notify_on_error?
       "error"
+    elsif args.no_notify_on_update?
+      "outdated"
     else
       "always"
     end

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -79,6 +79,7 @@ module Autoupdate
     notification_mode = case script[%r{notifier/notify\.sh "\$status" "\$run_log" (\w+)}, 1]
     when "always" then "yes"
     when "error" then "failures only"
+    when "outdated" then "upgrades available and failures only"
     else
       script.include?("/usr/bin/open -g") ? "yes (legacy)" : "no"
     end

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -71,6 +71,7 @@ module Autoupdate
     details << "Schedule: every #{Autoupdate::Interval.describe(interval.to_i)} (#{interval} seconds)" if interval
     details << "Run at login: #{plist["RunAtLoad"] ? "yes" : "no"}"
     details << "Upgrade: #{upgrade_summary(status_script)}"
+    details << "Outdated: #{script.include?("#{Autoupdate::Core.brew} outdated") ? "yes" : "no"}"
     details << "Cleanup: #{script.include?("#{Autoupdate::Core.brew} cleanup") ? "yes" : "no"}"
     details << "AC power only: #{script.include?("/usr/bin/pmset -g ps") ? "yes" : "no"}"
     details << "Greedy cask upgrades: yes" if status_script.include?("upgrade --cask -v --greedy")

--- a/notifier/notify.sh
+++ b/notifier/notify.sh
@@ -46,7 +46,7 @@ then
         subtitle="${outdated_count} upgrades available"
       fi
       # Truncate the list to fit comfortably in a banner notification.
-      message=$(echo "${outdated_packages}" | /usr/bin/awk 'BEGIN { ORS=", " } { print } NR==5 { print "…"; exit }' | /usr/bin/sed 's/, $//')
+      message=$(echo "${outdated_packages}" | /usr/bin/awk 'BEGIN { ORS=", " } { print } NR==5 { print "…"; exit }' | /usr/bin/sed 's/, $//') || true
     else
       category="uptodate"
       message="Homebrew is already up-to-date."

--- a/notifier/notify.sh
+++ b/notifier/notify.sh
@@ -27,7 +27,7 @@ then
   elif /usr/bin/grep -q "Already up-to-date." "${run_log}"
   then
     outdated_packages=$(
-      /usr/bin/awk '/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { pkgs[NR]=$0 } !/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { delete pkgs; last_non_pkg=NR } END { for (i=last_non_pkg+1; i<=NR; i++) if (i in pkgs) print pkgs[i] }' "${run_log}"
+      /usr/bin/awk '/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { if (!done) pkgs = pkgs ? pkgs "\n" $0 : $0 } !/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { if (pkgs) done=1 } END { print pkgs }' "${run_log}"
     )
     outdated_count=$(echo "${outdated_packages}" | /usr/bin/grep -c . 2>/dev/null || true)
 

--- a/notifier/notify.sh
+++ b/notifier/notify.sh
@@ -17,20 +17,34 @@ then
   title="Homebrew autoupdate completed"
   subtitle="brew-autoupdate"
 
-  if /usr/bin/grep -q "Already up-to-date." "${run_log}"
-  then
-    message="Homebrew is already up-to-date."
-  else
-    upgrade_line=$(
-      /usr/bin/awk '/==> Upgrading [0-9]+ outdated packages?:/ { line = $0 } END { print line }' "${run_log}"
-    )
-  fi
+  upgrade_line=$(
+    /usr/bin/awk '/==> Upgrading [0-9]+ outdated packages?:/ { line = $0 } END { print line }' "${run_log}"
+  )
 
   if [[ -n "${upgrade_line:-}" ]]
   then
     message=${upgrade_line}
-  elif [[ -z "${message:-}" ]]
+  elif /usr/bin/grep -q "Already up-to-date." "${run_log}"
   then
+    outdated_packages=$(
+      /usr/bin/awk '/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { pkgs[NR]=$0 } !/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { delete pkgs; last_non_pkg=NR } END { for (i=last_non_pkg+1; i<=NR; i++) if (i in pkgs) print pkgs[i] }' "${run_log}"
+    )
+    outdated_count=$(echo "${outdated_packages}" | /usr/bin/grep -c . 2>/dev/null || true)
+
+    if [[ "${outdated_count}" -gt 0 ]]
+    then
+      if [[ "${outdated_count}" -eq 1 ]]
+      then
+        subtitle="1 upgrade available"
+      else
+        subtitle="${outdated_count} upgrades available"
+      fi
+      # Truncate the list to fit comfortably in a banner notification.
+      message=$(echo "${outdated_packages}" | /usr/bin/awk 'BEGIN { ORS=", " } { print } NR==5 { print "…"; exit }' | /usr/bin/sed 's/, $//')
+    else
+      message="Homebrew is already up-to-date."
+    fi
+  else
     message="Homebrew was updated successfully."
   fi
 else

--- a/notifier/notify.sh
+++ b/notifier/notify.sh
@@ -23,16 +23,22 @@ then
 
   if [[ -n "${upgrade_line:-}" ]]
   then
+    category="upgraded"
     message=${upgrade_line}
-  elif /usr/bin/grep -q "Already up-to-date." "${run_log}"
+  elif /usr/bin/grep -q "^==> autoupdate-outdated-begin$" "${run_log}"
   then
     outdated_packages=$(
-      /usr/bin/awk '/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { if (!done) pkgs = pkgs ? pkgs "\n" $0 : $0 } !/^[a-zA-Z0-9][a-zA-Z0-9@._-]*$/ { if (pkgs) done=1 } END { print pkgs }' "${run_log}"
+      /usr/bin/awk '
+        /^==> autoupdate-outdated-begin$/ { collecting = 1; next }
+        /^==> autoupdate-outdated-end$/   { collecting = 0; next }
+        collecting && NF                  { print }
+      ' "${run_log}"
     )
     outdated_count=$(echo "${outdated_packages}" | /usr/bin/grep -c . 2>/dev/null || true)
 
     if [[ "${outdated_count}" -gt 0 ]]
     then
+      category="outdated"
       if [[ "${outdated_count}" -eq 1 ]]
       then
         subtitle="1 upgrade available"
@@ -42,12 +48,19 @@ then
       # Truncate the list to fit comfortably in a banner notification.
       message=$(echo "${outdated_packages}" | /usr/bin/awk 'BEGIN { ORS=", " } { print } NR==5 { print "…"; exit }' | /usr/bin/sed 's/, $//')
     else
+      category="uptodate"
       message="Homebrew is already up-to-date."
     fi
+  elif /usr/bin/grep -q "Already up-to-date." "${run_log}"
+  then
+    category="uptodate"
+    message="Homebrew is already up-to-date."
   else
+    category="uptodate"
     message="Homebrew was updated successfully."
   fi
 else
+  category="failure"
   title="Homebrew autoupdate failed"
   subtitle="Exit status ${status}"
   message=$(
@@ -57,6 +70,11 @@ else
     }' "${run_log}"
   )
   message=${message:-"See the autoupdate log for details."}
+fi
+
+if [[ "${mode}" = "outdated" ]] && [[ "${category}" != "outdated" ]] && [[ "${category}" != "failure" ]]
+then
+  exit 0
 fi
 
 if [[ "${AUTUPDATE_NOTIFY_PRINT:-0}" = "1" ]]

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -35,6 +35,7 @@ class CommandTest < Minitest::Test
     assert_predicate status, :success?, stderr
     assert_includes stdout, "Usage: brew autoupdate start"
     assert_includes stdout, "--upgrade"
+    assert_includes stdout, "--outdated"
     assert_includes stdout, "--cleanup"
     assert_includes stdout, "--notify-on-error"
     assert_includes stdout, "--no-notify"
@@ -57,6 +58,11 @@ class CommandTest < Minitest::Test
 
     refute_predicate status, :success?
     assert_includes output, "The `status` subcommand does not accept the `--upgrade` switch."
+
+    output, status = brew_autoupdate_error("status", "--outdated")
+
+    refute_predicate status, :success?
+    assert_includes output, "The `status` subcommand does not accept the `--outdated` switch."
   end
 
   def test_upgrade_options_enforce_dependencies_and_conflicts
@@ -117,6 +123,17 @@ class CommandTest < Minitest::Test
     upgrade_lines.each do |line|
       assert_includes line, "upgrade --no-ask"
     end
+  end
+
+  def test_outdated_flag_precedes_upgrade_and_uses_safe_exit
+    source = File.read(File.join(ROOT, "lib/autoupdate/start.rb"))
+    outdated_pos = source.index("outdated --quiet")
+    upgrade_pos = source.index("upgrade --no-ask")
+
+    assert outdated_pos, "--outdated must appear in start.rb"
+    assert upgrade_pos, "--upgrade must appear in start.rb"
+    assert_operator outdated_pos, :<, upgrade_pos, "--outdated must precede --upgrade in the generated script"
+    assert_includes source, "outdated --quiet || true"
   end
 
   private

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -38,6 +38,7 @@ class CommandTest < Minitest::Test
     assert_includes stdout, "--outdated"
     assert_includes stdout, "--cleanup"
     assert_includes stdout, "--notify-on-error"
+    assert_includes stdout, "--no-notify-on-update"
     assert_includes stdout, "--no-notify"
     refute_includes stdout, "--follow"
     refute_includes stdout, "--lines"
@@ -83,7 +84,24 @@ class CommandTest < Minitest::Test
     output, status = brew_autoupdate_error("start", "--notify-on-error", "--no-notify")
 
     refute_predicate status, :success?
-    assert_includes output, "Options --notify-on-error and --no-notify are mutually exclusive."
+    assert_includes output, "mutually exclusive"
+
+    output, status = brew_autoupdate_error("start", "--outdated", "--no-notify-on-update", "--no-notify")
+
+    refute_predicate status, :success?
+    assert_includes output, "mutually exclusive"
+
+    output, status = brew_autoupdate_error("start", "--outdated", "--no-notify-on-update", "--notify-on-error")
+
+    refute_predicate status, :success?
+    assert_includes output, "mutually exclusive"
+  end
+
+  def test_no_notify_on_update_requires_outdated
+    output, status = brew_autoupdate_error("start", "--no-notify-on-update")
+
+    refute_predicate status, :success?
+    assert_includes output, "`--no-notify-on-update` cannot be passed without `--outdated`."
   end
 
   def test_invalid_intervals_are_rejected_before_starting
@@ -134,6 +152,8 @@ class CommandTest < Minitest::Test
     assert upgrade_pos, "--upgrade must appear in start.rb"
     assert_operator outdated_pos, :<, upgrade_pos, "--outdated must precede --upgrade in the generated script"
     assert_includes source, "outdated --quiet || true"
+    assert_includes source, "autoupdate-outdated-begin"
+    assert_includes source, "autoupdate-outdated-end"
   end
 
   private

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -20,7 +20,8 @@ class NotifierTest < Minitest::Test
   end
 
   def test_reports_outdated_packages
-    output, status = summarize(0, "Already up-to-date.\nawscli\ngradle\n")
+    log = "Already up-to-date.\n==> autoupdate-outdated-begin\nawscli\ngradle\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log)
 
     assert_predicate status, :success?
     assert_includes output, "2 upgrades available"
@@ -28,7 +29,8 @@ class NotifierTest < Minitest::Test
   end
 
   def test_reports_single_outdated_package
-    output, status = summarize(0, "Already up-to-date.\nawscli\n")
+    log = "Already up-to-date.\n==> autoupdate-outdated-begin\nawscli\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log)
 
     assert_predicate status, :success?
     assert_includes output, "1 upgrade available"
@@ -37,7 +39,8 @@ class NotifierTest < Minitest::Test
 
   def test_truncates_long_outdated_list
     packages = (1..6).map { |i| "pkg#{i}" }.join("\n")
-    output, status = summarize(0, "Already up-to-date.\n#{packages}\n")
+    log = "Already up-to-date.\n==> autoupdate-outdated-begin\n#{packages}\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log)
 
     assert_predicate status, :success?
     assert_includes output, "6 upgrades available"
@@ -75,6 +78,62 @@ class NotifierTest < Minitest::Test
 
     assert_predicate status, :success?
     assert_empty output
+  end
+
+  def test_outdated_mode_suppresses_uptodate_notifications
+    log = "Already up-to-date.\n==> autoupdate-outdated-begin\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log, mode: "outdated")
+
+    assert_predicate status, :success?
+    assert_empty output
+  end
+
+  def test_outdated_mode_suppresses_upgraded_notifications
+    output, status = summarize(0, "==> Upgrading 2 outdated packages:\nfoo bar\n", mode: "outdated")
+
+    assert_predicate status, :success?
+    assert_empty output
+  end
+
+  def test_outdated_mode_emits_when_packages_are_available
+    log = "Already up-to-date.\n==> autoupdate-outdated-begin\nawscli\ngradle\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log, mode: "outdated")
+
+    assert_predicate status, :success?
+    assert_includes output, "2 upgrades available"
+    assert_includes output, "awscli, gradle"
+  end
+
+  def test_outdated_mode_emits_on_failure
+    output, status = summarize(2, "fatal error\n", mode: "outdated")
+
+    assert_predicate status, :success?
+    assert_includes output, "Homebrew autoupdate failed"
+  end
+
+  def test_sentinel_markers_take_precedence_over_brew_update_name_blocks
+    # brew update prints its own bare-name lists (e.g. "==> New Formulae"); the
+    # markers must select only the brew outdated output.
+    log = "==> Updating Homebrew...\nUpdated Homebrew from abc to def.\n==> New Formulae\nzigmod\nzls\n" \
+          "==> autoupdate-outdated-begin\nawscli\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log)
+
+    assert_predicate status, :success?
+    assert_includes output, "1 upgrade available"
+    assert_includes output, "awscli"
+    refute_includes output, "zigmod"
+    refute_includes output, "zls"
+  end
+
+  def test_sentinel_markers_report_outdated_when_brew_update_pulled_commits
+    # brew update does not print "Already up-to-date." when it fetches new commits.
+    log = "==> Updating Homebrew...\nUpdated Homebrew from abc to def.\n" \
+          "==> autoupdate-outdated-begin\nawscli\n==> autoupdate-outdated-end\n"
+    output, status = summarize(0, log)
+
+    assert_predicate status, :success?
+    assert_includes output, "1 upgrade available"
+    assert_includes output, "awscli"
   end
 
   def test_committed_app_matches_the_shared_version

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -19,6 +19,32 @@ class NotifierTest < Minitest::Test
     assert_includes output, "Homebrew is already up-to-date."
   end
 
+  def test_reports_outdated_packages
+    output, status = summarize(0, "Already up-to-date.\nawscli\ngradle\n")
+
+    assert_predicate status, :success?
+    assert_includes output, "2 upgrades available"
+    assert_includes output, "awscli, gradle"
+  end
+
+  def test_reports_single_outdated_package
+    output, status = summarize(0, "Already up-to-date.\nawscli\n")
+
+    assert_predicate status, :success?
+    assert_includes output, "1 upgrade available"
+    assert_includes output, "awscli"
+  end
+
+  def test_truncates_long_outdated_list
+    packages = (1..6).map { |i| "pkg#{i}" }.join("\n")
+    output, status = summarize(0, "Already up-to-date.\n#{packages}\n")
+
+    assert_predicate status, :success?
+    assert_includes output, "6 upgrades available"
+    assert_includes output, "…"
+    refute_includes output, "pkg6"
+  end
+
   def test_reports_an_upgrade_count
     output, status = summarize(0, "==> Upgrading 3 outdated packages:\nfoo\nbar\n")
 


### PR DESCRIPTION
Add :
* `--outdated` to reports available upgrades.
* `--no-notify-on-update` Notify only when upgrades are available or a run fails. (Requires `--outdated`)

Example output when run with `brew autoupdate start 2h --cleanup --outdated --immediate --no-notify-on-update`
<img width="354" height="275" alt="image" src="https://github.com/user-attachments/assets/2eb6dddd-f8dd-4ed9-b0f5-6c6dbac66907" />


Built using clankers, but I've reviewed the code.

I think this addresses https://github.com/DomT4/homebrew-autoupdate/issues/122