### PR TITLE
Support Scheduling with 24H clock time

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ background.
 
 Now run `brew autoupdate start [interval] [options]` to enable autoupdate.
 The interval defaults to 24 hours and accepts seconds or a short duration such
-as `30m`, `12h`, or `1d`.
+as `30m`, `12h`, or `1d`, or a 24-hour clock time such as `00:00` to run daily
+at that specific time instead of relative to when the command was run.
 
 _Note:_
 _To ensure that auto-updated cask-based apps are updated in place (so they stay on your Dock), add `~/Library/Application Support/com.github.domt4.homebrew-autoupdate/brew_autoupdate` to System Settings / Privacy and Security / App Management. (Also allow ruby and Terminal.app)_
@@ -71,6 +72,18 @@ versioned formulae (`node@20`).
 Cannot be combined with `--leaves-only`. To change which packages are
 auto-upgraded, run `brew autoupdate delete` then start again with the new list.
 
+### Run at a specific time every day
+
+```sh
+brew autoupdate start 00:00 --upgrade --cleanup
+```
+
+Instead of a duration, pass a 24-hour clock time (`HH:MM`) to schedule the run
+via `launchd`'s `StartCalendarInterval` at that exact wall-clock time every
+day, rather than a relative interval measured from whenever the command was
+run (which drifts and won't line up with midnight, or any other fixed time,
+over repeated runs).
+
 ## Usage
 
 <!-- HELP-COMMAND-OUTPUT:START -->
@@ -88,7 +101,9 @@ Start autoupdating with:
   brew autoupdate start [interval] [options]
 
 The interval defaults to 24 hours. It can be provided as seconds or as a
-duration such as 30m, 12h, 1d, or 1w.
+duration such as 30m, 12h, 1d, or 1w, or as a 24-hour clock time such as
+00:00 to run daily at that specific time instead of relative to when the
+command was run.
 
 Common start options:
   --upgrade upgrades installed formulae and casks.
@@ -106,6 +121,7 @@ Examples:
   brew autoupdate start
   brew autoupdate start 12h --upgrade --cleanup --immediate
   brew autoupdate start 1d --upgrade --only=wget,node,firefox
+  brew autoupdate start 00:00 --upgrade --cleanup
   brew autoupdate logs --lines=50
   brew autoupdate logs --follow
 
@@ -134,7 +150,8 @@ Subcommands:
 From tap: domt4/autoupdate
 Usage: brew autoupdate start [interval] [options]:
     Start autoupdating in the background. The interval defaults to 24 hours and
-accepts seconds or a suffix such as 30m, 12h, or 1d.
+accepts seconds or a suffix such as 30m, 12h, or 1d, or a 24-hour clock
+time such as 00:00 to run daily at that specific time.
 
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -19,7 +19,8 @@ module Homebrew
             `brew autoupdate start [<interval>] [<options>]`
 
           The interval defaults to 24 hours. It can be provided as seconds or as a duration
-          such as `30m`, `12h`, `1d`, or `1w`.
+          such as `30m`, `12h`, `1d`, or `1w`, or as a 24-hour clock time such as `00:00` to
+          run daily at that specific time instead of relative to when the command was run.
 
           Common start options:
             `--upgrade` upgrades installed formulae and casks.
@@ -37,6 +38,7 @@ module Homebrew
             `brew autoupdate start`
             `brew autoupdate start 12h --upgrade --cleanup --immediate`
             `brew autoupdate start 1d --upgrade --only=wget,node,firefox`
+            `brew autoupdate start 00:00 --upgrade --cleanup`
             `brew autoupdate logs --lines=50`
             `brew autoupdate logs --follow`
 
@@ -54,7 +56,8 @@ module Homebrew
             `autoupdate start` [<interval>] [<options>]:
             Start autoupdating in the background.
             The interval defaults to 24 hours and accepts seconds or a suffix such as
-            `30m`, `12h`, or `1d`.
+            `30m`, `12h`, or `1d`, or a 24-hour clock time such as `00:00` to run daily
+            at that specific time.
           EOS
 
           switch "--upgrade",

--- a/lib/autoupdate/interval.rb
+++ b/lib/autoupdate/interval.rb
@@ -11,12 +11,24 @@ module Autoupdate
       "w" => 7 * 24 * 60 * 60,
     }.freeze
 
+    # A specific wall-clock time of day (24-hour, local time) to run daily at,
+    # as opposed to a relative interval measured from when the job was loaded.
+    CalendarTime = Struct.new(:hour, :minute) do
+      def to_s
+        format("%<hour>02d:%<minute>02d", hour: hour, minute: minute)
+      end
+    end
+
     class InvalidIntervalError < ArgumentError; end
 
     module_function
 
     def parse(value)
       return DEFAULT_SECONDS if value.nil?
+
+      if (match = value.match(/\A([01]?\d|2[0-3]):([0-5]\d)\z/))
+        return CalendarTime.new(match[1].to_i, match[2].to_i)
+      end
 
       match = value.match(/\A(\d+)([smhdw]?)\z/i)
       raise InvalidIntervalError, invalid_interval_message unless match
@@ -27,7 +39,10 @@ module Autoupdate
       amount * UNITS.fetch(match[2].downcase, 1)
     end
 
-    def describe(seconds)
+    def describe(value)
+      return "day at #{value}" if value.is_a?(CalendarTime)
+
+      seconds = value
       amount, unit = [
         [UNITS.fetch("w"), "week"],
         [UNITS.fetch("d"), "day"],
@@ -41,7 +56,8 @@ module Autoupdate
     end
 
     def invalid_interval_message
-      "The interval must be positive seconds or a duration such as `30m`, `12h`, or `1d`."
+      "The interval must be positive seconds, a duration such as `30m`, `12h`, or `1d`, " \
+        "or a 24-hour clock time such as `00:00` to run daily at that time."
     end
   end
 end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -213,6 +213,26 @@ module Autoupdate
       ""
     end
 
+    # A CalendarTime schedules a fixed wall-clock time daily via
+    # StartCalendarInterval; anything else is a relative StartInterval,
+    # measured in seconds from whenever launchd loads the job.
+    schedule_xml = if interval.is_a?(Autoupdate::Interval::CalendarTime)
+      <<~EOS.chomp
+        <key>StartCalendarInterval</key>
+        <dict>
+          <key>Hour</key>
+          <integer>#{interval.hour}</integer>
+          <key>Minute</key>
+          <integer>#{interval.minute}</integer>
+        </dict>
+      EOS
+    else
+      <<~EOS.chomp
+        <key>StartInterval</key>
+        <integer>#{interval}</integer>
+      EOS
+    end
+
     file = <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -231,8 +251,7 @@ module Autoupdate
         <string>#{CGI.escapeHTML(log_out)}</string>
         <key>StandardOutPath</key>
         <string>#{CGI.escapeHTML(log_out)}</string>
-        <key>StartInterval</key>
-        <integer>#{interval}</integer>
+        #{schedule_xml}
         <key>LowPriorityBackgroundIO</key>
         <true/>
         <key>LowPriorityIO</key>

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -64,11 +64,17 @@ module Autoupdate
   def configuration_summary
     plist = Plist.parse_xml(Autoupdate::Core.plist, marshal: false) || {}
     interval = plist["StartInterval"]
+    calendar = plist["StartCalendarInterval"]
     script = updater_script
     status_script = script.gsub(" upgrade --no-ask", " upgrade")
     details = []
 
-    details << "Schedule: every #{Autoupdate::Interval.describe(interval.to_i)} (#{interval} seconds)" if interval
+    if calendar
+      calendar_time = Autoupdate::Interval::CalendarTime.new(calendar["Hour"].to_i, calendar["Minute"].to_i)
+      details << "Schedule: every #{Autoupdate::Interval.describe(calendar_time)}"
+    elsif interval
+      details << "Schedule: every #{Autoupdate::Interval.describe(interval.to_i)} (#{interval} seconds)"
+    end
     details << "Run at login: #{plist["RunAtLoad"] ? "yes" : "no"}"
     details << "Upgrade: #{upgrade_summary(status_script)}"
     details << "Cleanup: #{script.include?("#{Autoupdate::Core.brew} cleanup") ? "yes" : "no"}"

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -42,6 +42,13 @@ class CommandTest < Minitest::Test
     refute_includes stdout, "--lines"
   end
 
+  def test_start_help_documents_the_clock_time_schedule
+    stdout, stderr, status = brew_autoupdate("start", "--help")
+
+    assert_predicate status, :success?, stderr
+    assert_includes stdout, "00:00"
+  end
+
   def test_logs_help_lists_only_log_options
     stdout, stderr, status = brew_autoupdate("logs", "--help")
 
@@ -84,7 +91,14 @@ class CommandTest < Minitest::Test
     output, status = brew_autoupdate_error("start", "tomorrow")
 
     refute_predicate status, :success?
-    assert_includes output, "The interval must be positive seconds or a duration"
+    assert_includes output, "The interval must be positive seconds"
+  end
+
+  def test_invalid_clock_times_are_rejected_before_starting
+    output, status = brew_autoupdate_error("start", "24:00")
+
+    refute_predicate status, :success?
+    assert_includes output, "The interval must be positive seconds"
   end
 
   def test_log_line_count_must_be_positive

--- a/test/interval_test.rb
+++ b/test/interval_test.rb
@@ -29,4 +29,33 @@ class IntervalTest < Minitest::Test
     assert_equal "90 minutes", Autoupdate::Interval.describe(5_400)
     assert_equal "2 days", Autoupdate::Interval.describe(172_800)
   end
+
+  def test_accepts_a_24_hour_clock_time_as_a_daily_schedule
+    result = Autoupdate::Interval.parse("00:00")
+    assert_instance_of Autoupdate::Interval::CalendarTime, result
+    assert_equal 0, result.hour
+    assert_equal 0, result.minute
+
+    result = Autoupdate::Interval.parse("9:05")
+    assert_equal 9, result.hour
+    assert_equal 5, result.minute
+
+    result = Autoupdate::Interval.parse("23:59")
+    assert_equal 23, result.hour
+    assert_equal 59, result.minute
+  end
+
+  def test_rejects_invalid_clock_times
+    assert_raises(Autoupdate::Interval::InvalidIntervalError) do
+      Autoupdate::Interval.parse("24:00")
+    end
+    assert_raises(Autoupdate::Interval::InvalidIntervalError) do
+      Autoupdate::Interval.parse("12:60")
+    end
+  end
+
+  def test_describes_a_calendar_time_as_a_daily_schedule
+    assert_equal "day at 00:00", Autoupdate::Interval.describe(Autoupdate::Interval::CalendarTime.new(0, 0))
+    assert_equal "day at 09:05", Autoupdate::Interval.describe(Autoupdate::Interval::CalendarTime.new(9, 5))
+  end
 end


### PR DESCRIPTION
Allow `brew autoupdate start` to accept a 24-hour clock time (e.g. `00:00`) in addition to relative durations, scheduling via launchd's StartCalendarInterval instead of a StartInterval measured from whenever the command happened to run.