### PR TITLE
start: percent-decode pinentry output in the askpass helper

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -119,12 +119,41 @@ module Autoupdate
         EOS
       end
       set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
-      sudo_gui_script_contents = <<~EOS
+      sudo_gui_script_contents = <<~'EOS'
         #!/bin/sh
-        PATH="#{HOMEBREW_PREFIX}/bin"
+        PATH="@@HOMEBREW_PREFIX@@/bin"
+
+        # pinentry returns the passphrase on an Assuan "D" line with its bytes
+        # percent-encoded, so it has to be decoded before being handed to sudo.
+        assuan_decode() {
+          s=$1
+          while :; do
+            case $s in
+              *%*)
+                printf '%s' "${s%%\%*}"
+                s=${s#*%}
+                hex=${s%"${s#??}"}
+                s=${s#??}
+                case $hex in
+                  [0-9A-Fa-f][0-9A-Fa-f])
+                    printf "\\$(printf '%03o' "$((0x$hex))")"
+                    ;;
+                  *)
+                    printf '%%%s' "$hex"
+                    ;;
+                esac
+                ;;
+              *)
+                printf '%s' "$s"
+                return 0
+                ;;
+            esac
+          done
+        }
+
         (
-          export PINENTRY_USER_DATA="ICON=#{Autoupdate::Core.location/"notifier/applet.icns"},"
-          printf "%s\n" \
+          export PINENTRY_USER_DATA="ICON=@@ICON@@,"
+          printf '%s\n' \
             "OPTION allow-external-cache" \
             "SETOK OK" \
             "SETCANCEL Cancel" \
@@ -133,8 +162,18 @@ module Autoupdate
             "SETTITLE homebrew-autoupdate Password Request" \
             "GETPIN" \
             | pinentry-mac --no-global-grab --timeout 60
-        ) | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
+        ) | while IFS= read -r line; do
+              case $line in
+                "D "*)
+                  assuan_decode "${line#D }"
+                  exit 0
+                  ;;
+              esac
+            done
       EOS
+      sudo_gui_script_contents = sudo_gui_script_contents
+                                 .gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX.to_s)
+                                 .gsub("@@ICON@@", (Autoupdate::Core.location/"notifier/applet.icns").to_s)
     elsif env_sudo
       set_env << "\n#{shell_export("SUDO_ASKPASS", env_sudo)}"
     end


### PR DESCRIPTION
## Summary

The askpass helper generated by `brew autoupdate start --sudo` corrupts passphrases
before handing them to `sudo`. The symptom users see is repeated password prompts -
one per privileged operation - which looks like a `sudo` credential-caching problem
but isn't.

The helper extracts the passphrase from pinentry with:

```sh
awk '/^D / {print substr($0, index($0, $2))}'
```

introduced in 712d8f5 (Oct 2023) and unchanged since.

## Two defects

**1. No Assuan percent-decoding.**
pinentry returns the passphrase on a `D` line with bytes percent-encoded. The helper
never decodes them, so a passphrase containing `%` arrives at `sudo` as `%25`.

**2. Payload located by search instead of by offset.**
`index($0, $2)` finds the first whitespace-delimited token of the passphrase anywhere
in the line, rather than using the protocol's fixed two-character offset. Consequences:

- a **leading** space or tab is silently dropped (awk collapses whitespace when
  splitting fields, so the field no longer reflects the original position);
- a passphrase of exactly `D` matches at position 1 and yields `D D`.

Interior spaces are unaffected - those work correctly today.

## Why this presents as a caching bug

When `sudo` receives a corrupted password, authentication fails, so **no timestamp
record is written**. There is nothing for `timestamp_timeout` to cache, and the next
privileged step prompts again. A cask upgrade performs several privileged operations
(`launchctl` unloads, `pkgutil --forget`, deletions under `/Library`, then the
installer), so the user is prompted once per operation.

This is very likely the cause of #145 ("Admin password is asked multiple times"),
which was closed without diagnosis. The reporter there wrote:

> I already tried setting a value for `timestamp_timeout` and using `getpass.sh`,
> but nothing worked.

That is exactly the expected outcome: tuning `timestamp_timeout` cannot help, because
no successful authentication ever occurs for it to cache. The reported symptom
(repeated prompts) and the actual bug (silent password corruption) are one step apart,
which is probably why the issue went unresolved.

Once the passphrase decodes correctly, a single authentication covers an entire run -
`sudo`'s default `timestamp_type=tty` falls back to `ppid` when no terminal is present,
and every `sudo` call in a run shares the same `brew` parent process.

## The fix

Replace the awk with a POSIX `sh` decoder that reads the `D` line at its fixed offset
and percent-decodes byte-wise, without external commands - no `perl`, and no
GNU-specific awk features (`strtonum` is unavailable in the BWK awk that macOS ships,
so hex decoding in awk is not portable here).

```sh
assuan_decode() {
  s=$1
  while :; do
    case $s in
      *%*)
        printf '%s' "${s%%\%*}"
        s=${s#*%}
        hex=${s%"${s#??}"}
        s=${s#??}
        case $hex in
          [0-9A-Fa-f][0-9A-Fa-f])
            printf "\\$(printf '%03o' "$((0x$hex))")"
            ;;
          *)
            printf '%%%s' "$hex"
            ;;
        esac
        ;;
      *)
        printf '%s' "$s"
        return 0
        ;;
    esac
  done
}
```

and the consumer becomes:

```sh
) | while IFS= read -r line; do
      case $line in
        "D "*)
          assuan_decode "${line#D }"
          exit 0
          ;;
      esac
    done
```

Malformed sequences (a trailing bare `%`) are emitted verbatim rather than swallowed.

**Second change: non-interpolating heredoc.** The generated script is built in a
`<<~EOS` heredoc, so every backslash in the shell has to be doubled for Ruby. That is
easy to get wrong, and has already produced a latent defect on `main`: the `\n` in
`printf "%s\n"` is consumed by Ruby, so the emitted helper has its printf format string
split across two physical lines. Switching to `<<~'EOS'` with named placeholders lets the
shell be written verbatim:

```ruby
sudo_gui_script_contents = <<~'EOS'
  #!/bin/sh
  PATH="@@HOMEBREW_PREFIX@@/bin"
  ...
EOS
sudo_gui_script_contents = sudo_gui_script_contents
                           .gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX.to_s)
                           .gsub("@@ICON@@", (Autoupdate::Core.location/"notifier/applet.icns").to_s)
```

It fixes the `printf` formatting as a side effect.

## Why the helper stays inline

The helper lived at `gui/getpass.sh` until 712d8f5, which inlined it to resolve the
`#TODO: Fix ... path to script` left by cd3d45b in the same PR (#110). That reasoning
still holds: the script has to end up in `Core.location` regardless, since that is what
`SUDO_ASKPASS` points at and what `delete` cleans up, so a source file in the tap would
only add a copy step. The non-interpolating heredoc addresses the escaping hazard that
would otherwise argue for splitting it back out.

## Verification

Generated helper diffed against the current one using a stub pinentry that emits a
known `D` line:

| passphrase on the wire | current | patched |
|---|---|---|
| `p%25ss`    | `p%25ss` ✗   | `p%ss` ✓    |
| `caf%C3%A9` | `caf%C3%A9` ✗| `café` ✓    |
| `café` (unescaped) | `café` ✓ | `café` ✓ |
| `abc def`   | `abc def` ✓  | `abc def` ✓ |
| ` lead`     | `lead` ✗     | ` lead` ✓   |
| `D`         | `D D` ✗      | `D` ✓       |
| `plain`     | `plain` ✓    | `plain` ✓   |

Confirmed on a real machine: before the fix, a single `brew upgrade --cask` run logged
7 prompts and 27 rejected-password events across the history
(`sorry, try again` / `incorrect password`); after it, a single prompt covered several
packages requiring sudo in the same run, with zero sudo failures.

Also verified against real `pinentry-mac` rather than only a stub. Capturing the wire
data from one prompt and decoding it both ways confirms pinentry does escape:

```
wire sent by pinentry : %25...%25
current awk           : %25...%25   (literal, plus a trailing newline from print)
patched decoder       : %...%
```

And end-to-end against real `sudo`, using the generated helper as `SUDO_ASKPASS`:

```
sudo -k
SUDO_ASKPASS=<helper> sudo -A /usr/bin/true   -> exit 0, authenticated
SUDO_ASKPASS=<helper> sudo -A /usr/bin/true   -> no prompt, timestamp reused
```

The second call not prompting is the point: once the passphrase decodes, one
authentication covers subsequent privileged calls. That is precisely what could not
happen while the password was being corrupted, and why `timestamp_timeout` appeared
to have no effect in #145.

Finally, exercised through the real code path rather than a harness: with the patch
applied to an installed tap, `brew autoupdate start --sudo` emitted a helper
byte-identical to the expected output, and that generated helper authenticated
successfully against real `sudo`.

Ruby syntax checked with `ruby -c`; generated shell checked with `sh -n`.
